### PR TITLE
bumping travis php versions, composer deps, lowering phpstan level

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,13 +2,9 @@ language: php
 
 sudo: false
 
-php:
-  - 7
-  - 7.1
-  - 7.2
-  - nightly
-
-env: TMPDIR=/tmp USE_XDEBUG=false
+env:
+  global:
+    - COMPOSER_ARGS="" TMPDIR=/tmp USE_XDEBUG=false
 
 branches:
   only:
@@ -16,7 +12,7 @@ branches:
 
 install:
   - phpenv rehash
-  - travis_retry composer install --no-interaction --prefer-source
+  - travis_retry composer update --no-interaction --prefer-source $COMPOSER_ARGS
 
 stages:
   - test
@@ -33,20 +29,39 @@ script:
 jobs:
   fast_finish: true
   allow_failures:
+    - php: 7.4snapshot
     - php: nightly
   include:
+    - php: 7.1
+      env: COMPOSER_ARGS="--prefer-lowest"
+    - php: 7.1
+    - php: 7.2
+      env: COMPOSER_ARGS="--prefer-lowest"
+    - php: 7.2
+    - php: 7.3
+      env: COMPOSER_ARGS="--prefer-lowest"
+    - php: 7.3
+    - php: 7.4snapshot
+      env: COMPOSER_ARGS="--ignore-platform-reqs --prefer-lowest"
+    - php: 7.4snapshot
+      env: COMPOSER_ARGS="--ignore-platform-reqs"
+    - php: nightly
+      env: COMPOSER_ARGS="--ignore-platform-reqs --prefer-lowest"
+    - php: nightly
+      env: COMPOSER_ARGS="--ignore-platform-reqs"
+      
     - stage: style check
-      php: 7.1
+      php: 7.2
       env: TMPDIR=/tmp USE_XDEBUG=false
       script:
         - composer style-check
     - stage: phpstan analysis
-      php: 7.1
+      php: 7.2
       env: TMPDIR=/tmp USE_XDEBUG=false
       script:
         - composer phpstan
     - stage: test with coverage
-      php: 7.1
+      php: 7.2
       env: TMPDIR=/tmp USE_XDEBUG=true CC_TEST_REPORTER_ID=8f28da13e0ea0172cf806fdf90c46437edc8b2bda156e9849e9b2d2215df8cd1
       before_script:
         - curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter

--- a/composer.json
+++ b/composer.json
@@ -43,7 +43,7 @@
         "phpunit/phpunit": "^7.0",
         "phpstan/phpstan": "^0.11.2",
         "jetbrains/phpstorm-stubs": "dev-phpstan",
-        "pear/archive_tar": "^1.4",
+        "pear/archive_tar": "^1.4.6",
         "friendsofphp/php-cs-fixer": "^2.11",
         "maglnet/composer-require-checker": "^1.1.0",
         "phpro/grumphp": "^0.14.0"

--- a/composer.json
+++ b/composer.json
@@ -40,12 +40,12 @@
         }
     ],
     "require-dev": {
-        "phpunit/phpunit": "^6.0",
-        "phpstan/phpstan": "^0.9.2",
+        "phpunit/phpunit": "^7.0",
+        "phpstan/phpstan": "^0.11.2",
         "jetbrains/phpstorm-stubs": "dev-phpstan",
         "pear/archive_tar": "^1.4",
         "friendsofphp/php-cs-fixer": "^2.11",
-        "maglnet/composer-require-checker": "^0.1.6 | ^0.2.1",
+        "maglnet/composer-require-checker": "^1.1.0",
         "phpro/grumphp": "^0.14.0"
     },
     "include-path": [
@@ -57,7 +57,7 @@
     "scripts": {
         "test": "phpunit",
         "test-with-coverage": "phpunit --coverage-clover=clover.xml",
-        "phpstan": "phpstan analyze -l6 -c phpstan.neon --no-progress ./ --ansi",
+        "phpstan": "phpstan analyze -c phpstan.neon --no-progress --ansi",
         "style-check": "php-cs-fixer fix --dry-run -vv"
     },
     "suggest": {

--- a/grumphp.yml.dist
+++ b/grumphp.yml.dist
@@ -9,7 +9,6 @@ parameters:
             allow_risky: true
             config: .php_cs
         phpstan:
-            level: 6
             configuration: phpstan.neon
         phpunit:
             metadata:

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,16 +1,14 @@
 parameters:
+    level: 2
+    paths:
+        - ./
     excludes_analyse:
         - %rootDir%/../../../tests/*
         - %rootDir%/../../../vendor/*
     bootstrap: %rootDir%/../../../phpstan-bootstrap.php
     ignoreErrors:
-        - '#Casting to .+ something that.s already .+\.#'
         # Unusual argument definition where param can either be Zend_Config|array or ...$args (if first param isn't Zend_Config|array)
-        - '#PHPDoc tag @param references unknown parameter \$charSet#'
+        - '#PHPDoc tag @param references unknown parameter: \$charSet#'
         # No stub for these yet
-        - '#Function lzf_compress not found\.#'
-        - '#Function lzf_decompress not found\.#'
         - '#Zend_Filter_.+::__construct\(\) does not call parent constructor from Zend_Filter_.+\.#'
         - '#Variable \$file might not be defined\.#'
-        - '#Parameter \#1 \$p_filelist of method Archive_Tar::create\(\) expects array, array\|string given\.#'
-        - '#Parameter \#3 \$locale of static method Zend_Locale::getTranslation\(\) expects string\|Zend_Locale\|null, array given\.#'

--- a/src/Zend/Filter/Compress/Tar.php
+++ b/src/Zend/Filter/Compress/Tar.php
@@ -169,8 +169,8 @@ class Zend_Filter_Compress_Tar extends Zend_Filter_Compress_CompressAbstract
         if (is_dir($content)) {
             // collect all file infos
             foreach (new RecursiveIteratorIterator(
-                        new RecursiveDirectoryIterator($content, RecursiveDirectoryIterator::KEY_AS_PATHNAME),
-                        RecursiveIteratorIterator::SELF_FIRST
+                new RecursiveDirectoryIterator($content, RecursiveDirectoryIterator::KEY_AS_PATHNAME),
+                RecursiveIteratorIterator::SELF_FIRST
                     ) as $directory => $info
             ) {
                 if ($info->isFile()) {

--- a/tests/Zend/Filter/AlnumTest.php
+++ b/tests/Zend/Filter/AlnumTest.php
@@ -74,7 +74,7 @@ class Zend_Filter_AlnumTest extends PHPUnit\Framework\TestCase
             $this->_locale               = new Zend_Locale('auto');
             self::$_meansEnglishAlphabet = in_array(
                 $this->_locale->getLanguage(),
-                                                    array('ja')
+                array('ja')
                                                     );
         }
     }

--- a/tests/Zend/Filter/AlphaTest.php
+++ b/tests/Zend/Filter/AlphaTest.php
@@ -74,7 +74,7 @@ class Zend_Filter_AlphaTest extends PHPUnit\Framework\TestCase
             $this->_locale               = new Zend_Locale('auto');
             self::$_meansEnglishAlphabet = in_array(
                 $this->_locale->getLanguage(),
-                                                    array('ja')
+                array('ja')
                                                     );
         }
     }

--- a/tests/Zend/Filter/LocalizedToNormalizedTest.php
+++ b/tests/Zend/Filter/LocalizedToNormalizedTest.php
@@ -90,7 +90,7 @@ class Zend_Filter_LocalizedToNormalizedTest extends PHPUnit\Framework\TestCase
                 'date_format' => 'dd.MM.y',
                 'locale'      => 'de',
                 'day'         => '20',
-                'month'       => '04',
+                'month'       => '4',
                 'year'        => '2009')
         );
 
@@ -112,7 +112,7 @@ class Zend_Filter_LocalizedToNormalizedTest extends PHPUnit\Framework\TestCase
                 'date_format' => 'yyyy.dd.MM',
                 'locale'      => 'de',
                 'day'         => '20',
-                'month'       => '04',
+                'month'       => '4',
                 'year'        => '2009'),
             '2009.20.04' => array(
                 'date_format' => 'yyyy.dd.MM',
@@ -130,7 +130,7 @@ class Zend_Filter_LocalizedToNormalizedTest extends PHPUnit\Framework\TestCase
                 'date_format' => 'yyyy.dd.MM',
                 'locale'      => 'de',
                 'day'         => '20',
-                'month'       => '04',
+                'month'       => '4',
                 'year'        => '2009')
         );
 
@@ -169,7 +169,7 @@ class Zend_Filter_LocalizedToNormalizedTest extends PHPUnit\Framework\TestCase
         $valuesExpected = array(
             '1.234,5678' => '1234.56',
             '1,234'      => '1.23',
-            '1.234'      => '1234.00'
+            '1.234'      => '1234'
         );
 
         foreach ($valuesExpected as $input => $output) {


### PR DESCRIPTION
I lowered the phpstan level because quite a few errors came up with the new version of phpstan, most of them due to external function signature changes. Many of them may require submitting PRs to phpstan to fix the internal function signature checking, which I don't have time for at the moment.